### PR TITLE
Fix: potential unexpected iterations due to missing EOF

### DIFF
--- a/bin/capture.fish
+++ b/bin/capture.fish
@@ -2,7 +2,7 @@
 
 function main
     while true
-        set user_input (read)
+        read --local user_input
 
         if test -n "$user_input"
             # Only procss non-empty input

--- a/bin/capture.fish
+++ b/bin/capture.fish
@@ -4,12 +4,10 @@ function main
     while true
         set user_input (read)
 
-        if test -z "$user_input"
-            # Skip empty input
-            continue
+        if test -n "$user_input"
+            # Only procss non-empty input
+            complete -C "$user_input"
         end
-
-        complete -C "$user_input"
 
         echo "EOF" >&2
     end


### PR DESCRIPTION
In a fish script, `EOF` is not emitted when `user_input` is empty.
That may result in an unexpected iterations.

I also refactored a script bit so to avoid shell substitutions.