### PR TITLE
Refactor zsh capture script

### DIFF
--- a/bin/ddc-source-shell_native/capture.zsh
+++ b/bin/ddc-source-shell_native/capture.zsh
@@ -2,145 +2,30 @@
 
 zmodload zsh/zpty || { echo 'error: missing module zsh/zpty' >&2; exit 1 }
 
-# Function to initialize the zpty shell with completion settings
-initialize_shell() {
+local zpty_rcfile=${0:h}/zptyrc.zsh
+[[ -r $zpty_rcfile ]] || { echo "error: rcfile not found: $zpty_rcfile" >&2; exit 1; }
 
+# Main loop to read from stdin and process completion
+while true; do
     # Spawn shell
     zpty z zsh -f -i
 
     # Line buffer for pty output
     local line
 
-    setopt rcquotes
-
+    # Initialize shell settings before processing
+    zpty -w z "source ${(qq)zpty_rcfile}"
     () {
-        zpty -w z source $1
         repeat 4; do
             zpty -r z line
             [[ $line == ok* ]] && return
         done
-        echo 'error initializing.' >&2
+        echo 'error: initialization failure' >&2
         exit 2
-    } =( <<< '
-    typeset -gx CACHE_DIR=${XDG_CACHE_HOME:-"$HOME/.cache"}/ddc-source-shell_native
-
-    mkdir -p "$CACHE_DIR"
-
-    # No prompt!
-    PROMPT=
-
-    # Load completion system
-    autoload -U compinit; compinit -C
-    compinit -d "$CACHE_DIR/compdump"
-
-    # Never run commands
-    bindkey ''^M'' undefined
-    bindkey ''^J'' undefined
-    bindkey ''^I'' complete-word
-
-    # Send a line with null-byte at the end before and after completions are output
-    null-line () {
-        echo -E - $''\0''
     }
-    compprefuncs=( null-line )
-    comppostfuncs=( null-line exit )
-
-    # Never group stuff!
-    zstyle '':completion:*'' list-grouped false
-    zstyle '':completion:*'' force-list always
-    # Don''t insert tab when attempting completion on empty line
-    zstyle '':completion:*'' insert-tab false
-    # No list separator, this saves some stripping later on
-    zstyle '':completion:*'' list-separator ''''
-    # for list even if too many
-    zstyle '':completion:*'' list-prompt   ''''
-    zstyle '':completion:*'' select-prompt ''''
-    zstyle '':completion:*'' menu true
-
-    # We use zparseopts
-    zmodload zsh/zutil
-
-    # Override compadd (this our hook)
-    compadd () {
-
-        # Check if any of -O, -A or -D are given
-        if [[ ${@[1,(i)(-|--)]} == *-(O|A|D)\ * ]]; then
-            # If that is the case, just delegate and leave
-            builtin compadd "$@"
-            return $?
-        fi
-
-        # OK, this concerns us!
-        # echo -E - got this: "$@"
-
-        # Be careful with namespacing here, we don''t want to mess with stuff
-        # that should be passed to compadd!
-        typeset -a __hits __dscr __tmp
-
-        # Do we have a description parameter?
-        # NOTE: we don''t use zparseopts here because of combined option
-        # parameters with arguments like -default- confuse it.
-        if (( $@[(I)-d] )); then # kind of a hack, $+@[(r)-d] doesn''t work because of line noise overload
-            # next param after -d
-            __tmp=${@[$[${@[(i)-d]}+1]]}
-            # description can be given as an array parameter name, or inline () array
-            if [[ $__tmp == \(* ]]; then
-                eval "__dscr=$__tmp"
-            else
-                __dscr=( "${(@P)__tmp}" )
-            fi
-        fi
-
-        # Capture completions by injecting -A parameter into the compadd call.
-        # This takes care of matching for us.
-        builtin compadd -A __hits -D __dscr "$@"
-
-        # JESUS CHRIST IT TOOK ME FOREVER TO FIGURE OUT THIS OPTION WAS SET AND WAS MESSING WITH MY SHIT HERE
-        setopt localoptions norcexpandparam extendedglob
-
-        # Extract prefixes and suffixes from compadd call. we can''t do zsh''s cool
-        # -r remove-func magic, but it''s better than nothing.
-        typeset -A apre hpre hsuf asuf
-        zparseopts -E P:=apre p:=hpre S:=asuf s:=hsuf
-
-        # Append / to directories? we are only emulating -f in a half-assed way
-        # here, but it''s better than nothing.
-        integer dirsuf=0
-        # don''t be fooled by -default- >.>
-        if [[ -z $hsuf && "${${@//-default-/}% -# *}" == *-[[:alnum:]]#f* ]]; then
-            dirsuf=1
-        fi
-
-        # Just drop
-        [[ -n $__hits ]] || return
-
-        # This is the point where we have all matches in $__hits and all
-        # descriptions in $__dscr!
-
-        # Display all matches
-        local dsuf dscr
-        for i in {1..$#__hits}; do
-
-            # Add a dir suffix?
-            (( dirsuf )) && [[ -d $__hits[$i] ]] && dsuf=/ || dsuf=
-            # Description to be displayed afterwards
-            (( $#__dscr >= $i )) && dscr=" -- ${${__dscr[$i]}##$__hits[$i] #}" || dscr=
-
-            echo -E - $IPREFIX$apre$hpre$__hits[$i]$dsuf$hsuf$asuf$dscr
-
-        done
-    }
-
-    # signal success!
-    echo ok')
-}
-
-# Main loop to read from stdin and process completion
-while true; do
-    # Initialize shell settings before processing
-    initialize_shell
 
     # Read input from stdin
+    local input
     IFS= read -r input || break
 
     # Trigger completion and send it to the pty

--- a/bin/ddc-source-shell_native/zptyrc.zsh
+++ b/bin/ddc-source-shell_native/zptyrc.zsh
@@ -102,7 +102,7 @@ compadd () {
         # Add a dir suffix?
         (( dirsuf )) && [[ -d $__hits[$i] ]] && dsuf=/ || dsuf=
         # Description to be displayed afterwards
-        (( $#__dscr >= $i )) && dscr=" -- ${${__dscr[$i]}##$__hits[$i] #}" || dscr=
+        (( $#__dscr >= $i )) && dscr=$'\t'"${${__dscr[$i]}##$__hits[$i] #}" || dscr=
 
         echo -E - $IPREFIX$apre$hpre$__hits[$i]$dsuf$hsuf$asuf$dscr
 

--- a/bin/ddc-source-shell_native/zptyrc.zsh
+++ b/bin/ddc-source-shell_native/zptyrc.zsh
@@ -2,14 +2,14 @@
 
 typeset -gx CACHE_DIR=${XDG_CACHE_HOME:-"$HOME/.cache"}/ddc-source-shell_native
 
-mkdir -p "$CACHE_DIR"
+[[ -d $CACHE_DIR ]] || mkdir -p "$CACHE_DIR"
 
 # No prompt!
 PROMPT=
 
 # Load completion system
-autoload -U compinit; compinit -C
-compinit -d "$CACHE_DIR/compdump"
+autoload -U compinit
+compinit -C -d "$CACHE_DIR/compdump"
 
 # Never run commands
 bindkey '^M' undefined

--- a/bin/ddc-source-shell_native/zptyrc.zsh
+++ b/bin/ddc-source-shell_native/zptyrc.zsh
@@ -12,16 +12,21 @@ autoload -U compinit
 compinit -C -d "$CACHE_DIR/compdump"
 
 # Never run commands
-bindkey '^M' undefined
-bindkey '^J' undefined
+bindkey -r '^M'
+bindkey -r '^J'
 bindkey '^I' complete-word
+bindkey '^U' kill-buffer
 
 # Send a line with null-byte at the end before and after completions are output
 null-line () {
     echo -E - $'\0'
 }
-compprefuncs=( null-line )
-comppostfuncs=( null-line exit )
+reset-compfuncs () {
+    # comp*funcs are cleared after completion, so we need to set them up again
+    compprefuncs=( null-line )
+    comppostfuncs=( null-line reset-compfuncs )
+}
+reset-compfuncs
 
 # Never group stuff!
 zstyle ':completion:*' list-grouped false
@@ -108,6 +113,3 @@ compadd () {
 
     done
 }
-
-# signal success!
-echo ok

--- a/bin/ddc-source-shell_native/zptyrc.zsh
+++ b/bin/ddc-source-shell_native/zptyrc.zsh
@@ -1,0 +1,113 @@
+# zpty shell completion settings
+
+typeset -gx CACHE_DIR=${XDG_CACHE_HOME:-"$HOME/.cache"}/ddc-source-shell_native
+
+mkdir -p "$CACHE_DIR"
+
+# No prompt!
+PROMPT=
+
+# Load completion system
+autoload -U compinit; compinit -C
+compinit -d "$CACHE_DIR/compdump"
+
+# Never run commands
+bindkey '^M' undefined
+bindkey '^J' undefined
+bindkey '^I' complete-word
+
+# Send a line with null-byte at the end before and after completions are output
+null-line () {
+    echo -E - $'\0'
+}
+compprefuncs=( null-line )
+comppostfuncs=( null-line exit )
+
+# Never group stuff!
+zstyle ':completion:*' list-grouped false
+zstyle ':completion:*' force-list always
+# Don't insert tab when attempting completion on empty line
+zstyle ':completion:*' insert-tab false
+# No list separator, this saves some stripping later on
+zstyle ':completion:*' list-separator ''
+# for list even if too many
+zstyle ':completion:*' list-prompt   ''
+zstyle ':completion:*' select-prompt ''
+zstyle ':completion:*' menu true
+
+# We use zparseopts
+zmodload zsh/zutil
+
+# Override compadd (this our hook)
+compadd () {
+
+    # Check if any of -O, -A or -D are given
+    if [[ ${@[1,(i)(-|--)]} == *-(O|A|D)\ * ]]; then
+        # If that is the case, just delegate and leave
+        builtin compadd "$@"
+        return $?
+    fi
+
+    # OK, this concerns us!
+    # echo -E - got this: "$@"
+
+    # Be careful with namespacing here, we don't want to mess with stuff
+    # that should be passed to compadd!
+    typeset -a __hits __dscr __tmp
+
+    # Do we have a description parameter?
+    # NOTE: we don't use zparseopts here because of combined option
+    # parameters with arguments like -default- confuse it.
+    if (( $@[(I)-d] )); then # kind of a hack, $+@[(r)-d] doesn't work because of line noise overload
+        # next param after -d
+        __tmp=${@[$[${@[(i)-d]}+1]]}
+        # description can be given as an array parameter name, or inline () array
+        if [[ $__tmp == \(* ]]; then
+            eval "__dscr=$__tmp"
+        else
+            __dscr=( "${(@P)__tmp}" )
+        fi
+    fi
+
+    # Capture completions by injecting -A parameter into the compadd call.
+    # This takes care of matching for us.
+    builtin compadd -A __hits -D __dscr "$@"
+
+    # JESUS CHRIST IT TOOK ME FOREVER TO FIGURE OUT THIS OPTION WAS SET AND WAS MESSING WITH MY SHIT HERE
+    setopt localoptions norcexpandparam extendedglob
+
+    # Extract prefixes and suffixes from compadd call. we can't do zsh's cool
+    # -r remove-func magic, but it's better than nothing.
+    typeset -A apre hpre hsuf asuf
+    zparseopts -E P:=apre p:=hpre S:=asuf s:=hsuf
+
+    # Append / to directories? we are only emulating -f in a half-assed way
+    # here, but it's better than nothing.
+    integer dirsuf=0
+    # don't be fooled by -default- >.>
+    if [[ -z $hsuf && "${${@//-default-/}% -# *}" == *-[[:alnum:]]#f* ]]; then
+        dirsuf=1
+    fi
+
+    # Just drop
+    [[ -n $__hits ]] || return
+
+    # This is the point where we have all matches in $__hits and all
+    # descriptions in $__dscr!
+
+    # Display all matches
+    local dsuf dscr
+    for i in {1..$#__hits}; do
+
+        # Add a dir suffix?
+        (( dirsuf )) && [[ -d $__hits[$i] ]] && dsuf=/ || dsuf=
+        # Description to be displayed afterwards
+        (( $#__dscr >= $i )) && dscr=" -- ${${__dscr[$i]}##$__hits[$i] #}" || dscr=
+
+        echo -E - $IPREFIX$apre$hpre$__hits[$i]$dsuf$hsuf$asuf$dscr
+
+    done
+}
+
+# signal success!
+echo ok

--- a/denops/@ddc-sources/shell_native.ts
+++ b/denops/@ddc-sources/shell_native.ts
@@ -189,21 +189,11 @@ export class Source extends BaseSource<Params> {
       input = input.slice(1);
     }
 
-    const delimiter = {
-      zsh: " -- ",
-      fish: "\t",
-    }[args.sourceParams.shell] ?? "";
-
     // Process collected lines
     const items = (await completer(input)).map((line) => {
       line = line.replace(/\/\/$/, "/"); // Replace the last //
-      if (delimiter === "") {
-        return { word: line };
-      }
-      const pieces = line.split(delimiter);
-      return pieces.length <= 1
-        ? { word: line }
-        : { word: pieces[0], info: pieces[1] };
+      const [word, info] = line.split("\t", 2);
+      return info ? { word, info } : { word };
     });
 
     return items;


### PR DESCRIPTION
- Moving the `zpty` initialization to a separate script helps with modularity and clarity.
- Spawning `zpty` only once per input reduces process overhead and should improve performance.
- Unifying the delimiter to a tab character for shell completion descriptions simplifies the logic and improves maintainability.