### PR TITLE
fix(zsh): remove unnecessary output of input variable

### DIFF
--- a/bin/ddc-source-shell_native/capture.zsh
+++ b/bin/ddc-source-shell_native/capture.zsh
@@ -16,9 +16,9 @@ zpty -w z "source ${(qq)zpty_rcfile} && echo ok || exit 2"
 zpty -r -m z line '*ok'$'\r' || { echo "error: pty initialization failure" >&2; exit 2 }
 
 # Main loop to read from stdin and process completion
+local input
 while true; do
     # Read input from stdin
-    local input
     IFS= read -r input || break
 
     zpty -t z || { echo "error: pty closed" >&2; exit 1 }

--- a/denops/@ddc-sources/shell_native.ts
+++ b/denops/@ddc-sources/shell_native.ts
@@ -207,7 +207,7 @@ export class Source extends BaseSource<Params> {
 
     // Process collected lines
     const items = (await completer(input))
-      .filter((line) => line.length > 0 && !line.startsWith("input="))
+      .filter((line) => line.length > 0)
       .map((line) => {
         line = line.replace(/\/\/$/, "/"); // Replace the last //
         const [word, info] = line.split("\t", 2);


### PR DESCRIPTION
Removes the unnecessary output of the `input={previous input value}` in `capture.zsh`.